### PR TITLE
feat: add copy link button

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -66,8 +66,18 @@ const issueLink = computed(() => {
 const toast = useToast()
 const { copy } = useClipboard()
 
+function resetVueVersion() {
+  vueVersion.value = null
+}
+
+function resetVueUseVersion() {
+  vueUseVersion.value = 'latest'
+}
+
 async function copyLink(e: MouseEvent) {
   if (e.metaKey) {
+    resetVueVersion()
+    resetVueUseVersion()
     // hidden logic for going to local debug from playground.vueuse.org
     window.location.href = `http://localhost:3000/${window.location.hash}`
     return

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -62,6 +62,23 @@ watch(() => route.fullPath, () => {
 const issueLink = computed(() => {
   return `https://github.com/vueuse/vueuse/issues/new?template=bug_report.yml&reproduction=${encodeURIComponent(currentHref.value)}`
 })
+
+const toast = useToast()
+const { copy } = useClipboard()
+
+async function copyLink(e: MouseEvent) {
+  if (e.metaKey) {
+    // hidden logic for going to local debug from playground.vueuse.org
+    window.location.href = `http://localhost:3000/${window.location.hash}`
+    return
+  }
+  copy(location.href)
+  toast.add({
+    title: 'Sharable URL has been copied to clipboard.',
+    icon: 'i-heroicons-check-circle',
+    color: 'success',
+  })
+}
 </script>
 
 <template>
@@ -85,6 +102,15 @@ const issueLink = computed(() => {
           aria-label="color mode"
           @click="toggleColorMode"
         />
+
+        <UTooltip text="Copy sharable URL">
+          <UButton
+            color="neutral"
+            variant="ghost"
+            icon="i-carbon-share"
+            @click="copyLink"
+          />
+        </UTooltip>
 
         <UTooltip text="Open on GitHub">
           <UButton


### PR DESCRIPTION
This PR ports the copy link button from [https://play.vuejs.org](https://github.com/ilyaliao/core/blob/f7dad6da2fd8e87e974b1b177b9e763d6d423853/packages-private/sfc-playground/src/Header.vue#L47-L56).
