### PR TITLE
fix: add @vueuse/components to import map

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -33,6 +33,7 @@ const vueUsePackages = [
   '@vueuse/metadata',
   '@vueuse/shared',
   '@vueuse/core',
+  '@vueuse/components',
   '@vueuse/integrations',
   '@vueuse/math',
   '@vueuse/rxjs',


### PR DESCRIPTION
Some demos require @vueuse/components, but the import map does not contain it.

For example: https://vueuse.org/core/onClickOutside/