### PR TITLE
fix: use +esm for vueuse >= 13

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,7 @@
 import type { OutputModes } from '@vue/repl'
 import type { ShallowRef } from 'vue'
 import { mergeImportMap, useStore, useVueImportMap } from '@vue/repl'
+import semver from 'semver'
 
 const showOutput = useRouteQuery<string, boolean>('showOutput', 'false', {
   transform: stringToBooleanTransformer,
@@ -40,7 +41,8 @@ const vueUsePackages = [
 ]
 
 function generateVueUseImportCDNs() {
-  const file = Number.parseInt(vueuseVersion.value) >= 13 ? '+esm' : 'index.mjs'
+  const version = semver.coerce(vueuseVersion.value)
+  const file = vueuseVersion.value === 'latest' || (version && semver.gte(version, '13.0.0')) ? '+esm' : 'index.mjs'
   return vueUsePackages.map((p) => {
     return [p, `https://cdn.jsdelivr.net/npm/${p}@${vueuseVersion.value}/${file}`]
   })


### PR DESCRIPTION
fixes #21 fixes #18

by fetching VueUse package.json module field on version changes.
There might be a better solution, but this makes it work for now.
